### PR TITLE
Add a test for tagging colour images encoded by opencv

### DIFF
--- a/tests/TestConstants.h.i
+++ b/tests/TestConstants.h.i
@@ -53,6 +53,10 @@ public:
         return testDataDir() + "opencv_colour.tif";
     }
 
+    static std::string OpenCVTiffColourOutputFile() {
+        return testDataDir() + "opencv_colour_output.tif";
+    }
+
     static void setTags (Tags & tags) {
 
     tags.imageHeight(1024);

--- a/tests/TestConstants.h.i
+++ b/tests/TestConstants.h.i
@@ -57,6 +57,10 @@ public:
         return testDataDir() + "opencv_colour_output.tif";
     }
 
+    static std::string OpenCVJpegColourOutputFile() {
+        return testDataDir() + "opencv_colour_output.jpg";
+    }
+
     static void setTags (Tags & tags) {
 
     tags.imageHeight(1024);

--- a/tests/TestConstants.h.i
+++ b/tests/TestConstants.h.i
@@ -49,6 +49,10 @@ public:
         return testDataDir() + "opencv_test_output.tif";
     };
 
+    static std::string OpenCVTiffColourFile() {
+        return testDataDir() + "opencv_colour.tif";
+    }
+
     static void setTags (Tags & tags) {
 
     tags.imageHeight(1024);

--- a/tests/TestImageHandler.cpp
+++ b/tests/TestImageHandler.cpp
@@ -233,6 +233,35 @@ TEST (TEST_ImageHandler, TestTiff_OpenCV_Colour) {
   ASSERT_NE(mat.data, nullptr);
 }
 
+TEST (TEST_ImageHandler, TestJpeg_OpenCV_Colour) {
+
+  cv::Mat mat;
+  std::vector<uint8_t> encoded_image;
+  mat = cv::imread(TagsTestCommon::OpenCVTiffColourFile());
+  cv::imencode(".jpg", mat, encoded_image);
+  
+  Tags tags;
+  TagsTestCommon::setTags(tags);
+
+  std::string error_message;
+  std::vector<uint8_t> out_image;
+  ASSERT_TRUE(ImageHandler::tagJpeg(tags, encoded_image, out_image, error_message));
+
+  FILE* pFile;
+  pFile = fopen(TagsTestCommon::OpenCVJpegColourOutputFile().c_str(), "wb");      
+  fwrite(out_image.data(), 1, out_image.size()*sizeof(unsigned char), pFile);
+  fclose(pFile);
+
+  Tags new_tags;
+  ASSERT_TRUE(new_tags.loadHeader(TagsTestCommon::OpenCVJpegColourOutputFile(), error_message));
+  TagsTestCommon::testTags(new_tags);
+
+  mat = cv::imread(TagsTestCommon::OpenCVJpegColourOutputFile());
+  ASSERT_EQ(mat.rows, 2048);
+  ASSERT_EQ(mat.cols, 2048);
+  ASSERT_NE(mat.data, nullptr);
+}
+
 TEST (TEST_ImageHandler, TestOpenCV_Load) {
 
   cv::Mat mat;

--- a/tests/TestImageHandler.cpp
+++ b/tests/TestImageHandler.cpp
@@ -197,6 +197,22 @@ TEST (TEST_ImageHandler, TestTIFF_OpenCV) {
     ASSERT_TRUE (new_tags.loadHeader(TagsTestCommon::OpenCVTiffOutputFile(), error_message));
 }
 
+TEST (TEST_ImageHandler, TestTiff_OpenCV_Colour_Encoded) {
+
+  cv::Mat mat;
+  std::vector<uint8_t> encoded_image;
+  mat = cv::imread(TagsTestCommon::OpenCVTiffColourFile());
+  cv::imencode(".tiff", mat, encoded_image);
+  
+  Tags tags;
+  std::string error_message;
+  std::vector<uint8_t> out_image;
+  ASSERT_TRUE(ImageHandler::tagTiff(tags, encoded_image, out_image, error_message));
+  ASSERT_TRUE(encoded_image.size() == 11463998);
+  ASSERT_TRUE(tags.stripOffsets().size() == tags.stripByteCount().size());
+  ASSERT_TRUE(tags.stripOffsets().size() == 1);
+}
+
 TEST (TEST_ImageHandler, TestOpenCV_Load) {
 
   cv::Mat mat;


### PR DESCRIPTION
Adds a test to caputure a bug that was discovered when testing the
ViewLS datatool v5.4.0.

Confirmed that versions  prior to
34957e51cc400488b8b95a95ffa4302e9ff64e231 fail to pass this test.